### PR TITLE
feat: add support for addresses

### DIFF
--- a/prisma/migrations/20240605182921_add_address_model/migration.sql
+++ b/prisma/migrations/20240605182921_add_address_model/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE `addresses` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `street` VARCHAR(255) NULL,
+    `city` VARCHAR(255) NULL,
+    `province` VARCHAR(255) NULL,
+    `country` VARCHAR(255) NOT NULL,
+    `postal_code` VARCHAR(255) NOT NULL,
+    `contact_id` INTEGER NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `addresses` ADD CONSTRAINT `addresses_contact_id_fkey` FOREIGN KEY (`contact_id`) REFERENCES `contacts`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,7 +33,22 @@ model Contact {
   phone      String  @db.VarChar(20)
   user_id    Int
 
-  user User @relation(fields: [user_id], references: [id])
+  user      User      @relation(fields: [user_id], references: [id])
+  addresses Address[]
 
   @@map("contacts")
+}
+
+model Address {
+  id          Int     @id @default(autoincrement())
+  street      String? @db.VarChar(255)
+  city        String? @db.VarChar(255)
+  province    String? @db.VarChar(255)
+  country     String  @db.VarChar(255)
+  postal_code String  @db.VarChar(255)
+  contact_id  Int
+
+  contact Contact @relation(fields: [contact_id], references: [id])
+
+  @@map("addresses")
 }


### PR DESCRIPTION
Adds a new `Address` model and adds a relation to it from the `Contact` model.

BREAKING CHANGE: The `Contact` model now has a new `addresses` field. Existing migrations will need to be updated to include the new `Address` model.
